### PR TITLE
chore(ci): make benchmark scheduled

### DIFF
--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -5,7 +5,10 @@ on:
       - master
       - develop
   push:
-    branches: master
+    branches:
+      - master
+  schedule:
+    - cron: 5 5 7 * * # run every 7th of the month at 05:05
 jobs:
   nim:
     strategy:


### PR DESCRIPTION
this should act as a workaround to the apparent 3 month log expiry within github actions